### PR TITLE
show file size with unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .idea/
+/lib/

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "filesize": "^3.3.0",
     "fs-extra": "^0.30.0",
     "webpack": "^1.13.1",
     "yargs": "^4.7.1"

--- a/src/SizeTree.js
+++ b/src/SizeTree.js
@@ -1,3 +1,4 @@
+import filesize from 'filesize';
 class SizeTree {
     constructor(key) {
         this.key = key;
@@ -59,8 +60,8 @@ export function buildSizeTree(webpackBundleStatJSON) {
 const log = (msg, tab = 0) => console.log(' '.repeat(tab) + msg);
 export function printSizeTree(sizeTree, tab = 0) {
     const {key, size, subSizeTreeMap} = sizeTree;
-    log(`${key}: ${size}`, tab);
-    log(`<self>: ${sizeTree.getSelfSize()}`, tab + 2);
+    log(`${key}: ${filesize(size)}`, tab);
+    log(`<self>: ${filesize(sizeTree.getSelfSize())}`, tab + 2);
     for (var subKey in subSizeTreeMap) {
         printSizeTree(subSizeTreeMap[subKey], tab + 2);
     }


### PR DESCRIPTION
Hi, Thanks for useful tool.
I think that showing file size with unit make more readable.
I've implemented this using [filesize.js](https://github.com/avoidwork/filesize.js).
### Before

```
__ROOT__: 762113
  <self>: 15253
  fbjs: 33098
    <self>: 33098
  object-assign: 896
    <self>: 896
  react: 595759
    <self>: 595759
  assert: 11706
    <self>: 11706
  almin: 57661
    <self>: 55667
    object-assign: 1994
      <self>: 1994
  lru-cache: 11113
    <self>: 11113
  process: 2056
    <self>: 2056
  util: 15766
    <self>: 15766
  events: 8191
    <self>: 8191
  inherits: 672
    <self>: 672
  pseudomap: 2717
    <self>: 2717
  react-dom: 63
    <self>: 63
  yallist: 7162
    <self>: 7162
```
### After

```
__ROOT__: 744.25 KB
  <self>: 14.9 KB
  fbjs: 32.32 KB
    <self>: 32.32 KB
  object-assign: 896 B
    <self>: 896 B
  react: 581.8 KB
    <self>: 581.8 KB
  assert: 11.43 KB
    <self>: 11.43 KB
  almin: 56.31 KB
    <self>: 54.36 KB
    object-assign: 1.95 KB
      <self>: 1.95 KB
  lru-cache: 10.85 KB
    <self>: 10.85 KB
  process: 2.01 KB
    <self>: 2.01 KB
  util: 15.4 KB
    <self>: 15.4 KB
  events: 8 KB
    <self>: 8 KB
  inherits: 672 B
    <self>: 672 B
  pseudomap: 2.65 KB
    <self>: 2.65 KB
  react-dom: 63 B
    <self>: 63 B
  yallist: 6.99 KB
    <self>: 6.99 KB
```
